### PR TITLE
got rid of the python forloop in LeastSampledClassesSampler

### DIFF
--- a/src/pytorch_multilabel_balanced_sampler/samplers.py
+++ b/src/pytorch_multilabel_balanced_sampler/samplers.py
@@ -91,8 +91,6 @@ class LeastSampledClassSampler(BaseMultilabelBalancedSampler):
 
         chosen_index = random.choice(self.class_indices[chosen_class])
 
-        for class_, indicator in enumerate(self.labels[self.indices[chosen_index]]):
-            if indicator == 1:
-                self.counts[class_] += 1
+        self.counts += (self.labels[self.indices[chosen_index]] == 1).int()
 
         return chosen_index


### PR DESCRIPTION
the for loop is replaced by pytorch logic. This makes the sampler way faster. It first took me over a minute for 1 epoch of my 38000sample dataset, now it is 9 seconds.
